### PR TITLE
exclude support array of clients to exclude

### DIFF
--- a/src/ClientList.js
+++ b/src/ClientList.js
@@ -173,6 +173,10 @@ API.excluding = function (exclude) {
    * Add anything not in the exclusion list.
    * Remember .filter is reactive.
    */
+  if(exclude instanceof Array){
+    exclude = new ClientList(exclude);
+  }
+  
   var list = this.filter(function (client) {
     var excluded = exclude.get(client.socket.id);
 


### PR DESCRIPTION
@PsychoLlama would you be up for accepting this?

A bunch of places in my code I have

`var carl = browsers.excluding(new panic.ClientList([alice, bob])).pluck(1);`

This commit would allow it to be simply

`var carl = browsers.excluding([alice, bob]).pluck(1);`

Which is just a slightly better experience :). Haven't found a single problem in panic so far, though!! So this is just a slight convenience touch.

Let me know! (I told you I wouldn't make any edits without asking you for approval first)